### PR TITLE
Fix metadata parsing

### DIFF
--- a/play
+++ b/play
@@ -22,7 +22,7 @@ header=$(echo "User-Agent: $user_agent" \
 
 _fetch_metadata() {
 parameter="$1"
-echo "$result" |  grep -Eo "meta property=\"og:$parameter\".*?" | grep -oh -P '(?<=content=\").*' | awk -F "\" />" '{print $1}'
+echo "$result" |  grep -Eo "meta property=\"og:$parameter\".*?" | grep -oh -P '(?<=content=\").*' | awk -F "\" ?/>" '{print $1}'
 }
 
 _format_output() {


### PR DESCRIPTION
Spotify no longer includes a space between the closing parenthesis and the `/>`. This was causing metadata parsing to fail and spew garbage into the output. Making the space optional should fix this while remaining backwards compatible.