### PR TITLE
Fix search result parsing

### DIFF
--- a/play
+++ b/play
@@ -54,7 +54,7 @@ qurl=$engine"/search?hl=en&q=$(echo $* | sed 's/ /+/g')"+"site:open.spotify.com/
 ###### Fetching key ######
 dom=`_http_request $qurl`
 key=$(echo "$dom" | \
-  grep -o '<a href=['"'"'"][^"'"'"']*['"'"'"]' | \
+  grep -o '<a [^>]* href=['"'"'"][^"'"'"']*['"'"'"]' | \
   sed -e 's/^<a href=["'"'"']//' -e 's/["'"'"']$//'  | \
   grep -i 'open.spotify.com/'$type/ | \
   grep -i 'https'  -m 1  | \


### PR DESCRIPTION
Google now includes a property in front of href. This was causing the parsing to fail to find the key.

This is the first part of the relevant link in the search result dom:

```html
<a jsname="UWckNb" href="https://open.spotify.com/album/1oX0tpdqOXCq3FqoPoQEnh"
```

Note that there is now `jsname="UWckNb"` in between `<a` and `href`.

Because of that, the grep command `grep -o '<a href=['"'"'"][^"'"'"']*['"'"'"]'` could no longer find the link

The changes update the regex to allow any number of characters between the start of the `a` tag and the href property, so long as we're still within the `a` tag
